### PR TITLE
JUST-A-TEST: move insipid dependency to end of requirements

### DIFF
--- a/.readthedocs_requirements.txt
+++ b/.readthedocs_requirements.txt
@@ -1,4 +1,4 @@
-insipid-sphinx-theme
 nbsphinx
 ipykernel
 sphinx-last-updated-by-git
+insipid-sphinx-theme


### PR DESCRIPTION
This is just a test. Not meant to be merged.